### PR TITLE
added index as extra param to the getLabel func

### DIFF
--- a/src/Components/HorizontalTimeline.jsx
+++ b/src/Components/HorizontalTimeline.jsx
@@ -16,7 +16,7 @@ import Constants from '../Constants';
  * @param {string} date The string representation of a date
  * @return {string} The formatted date string
  */
-const defaultGetLabel = (date) => (new Date(date)).toDateString().substring(4);
+const defaultGetLabel = (date, index) => (new Date(date)).toDateString().substring(4);
 
 /*
  * This is the Horizontal Timeline. This component expects an array of dates
@@ -48,7 +48,7 @@ class HorizontalTimeline extends React.Component {
     // Convert the distances and dates to events
     const events = distances.map((distance, index) => ({
       distance,
-      label: props.getLabel(props.values[index]),
+      label: props.getLabel(props.values[index], index),
       date: props.values[index],
     }));
 


### PR DESCRIPTION
for when you have 2 or more items in the underlying dataset with the same date, and you want to display them both (but with different label)
Here's my usecase:
![screen shot 2017-03-08 at 03 23 10](https://cloud.githubusercontent.com/assets/5514227/23685838/ebce033e-03ae-11e7-8926-672868a34179.png)
